### PR TITLE
Add lite transcription support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ request_object = TranscriptionRequest(
     metadata={"project": "example_project"}
 )
 
-# Transcribe a video file using the Complete Transcription engine
+# Transcribe a video file using the Full Transcription engine
 result = sdk.transcription_client.transcribe(
     "path/to/video.mp4",
     organization_name="your_organization_name",
     request=request_object,
-    engine=TranscriptionEngine.Complete,
+    engine=TranscriptionEngine.Full,
     auto_poll=True
 )
 
@@ -80,7 +80,7 @@ sdk.set_api_key("YOUR_API_KEY")
 ```
 
 ## Transcription Engines
-The SDK supports two transcription modes: `Complete` and `Lite`. The desired mode can be specified via the `engine` parameter of the `transcribe` method. When omitted it defaults to `Complete`. 
+The SDK supports two transcription modes: `Full` and `Lite`. The desired mode can be specified via the `engine` parameter of the `transcribe` method. When omitted it defaults to `Full`. 
 
 When using the `Lite` engine, the request object has to specify explicit defaults for a few of the properties:
 

--- a/src/salad_cloud_transcription_sdk/models/transcription_engine.py
+++ b/src/salad_cloud_transcription_sdk/models/transcription_engine.py
@@ -1,0 +1,14 @@
+from enum import Enum
+
+
+class TranscriptionEngine(Enum):
+    """
+    Enum representing the different transcription engine options.
+
+    Options:
+        - Complete: Complete transcription engine which siupports all features
+        - Lite: Lightweight transcription engine with less features, aimed at being faster
+    """
+
+    Complete = "complete"
+    Lite = "lite"

--- a/src/salad_cloud_transcription_sdk/models/transcription_engine.py
+++ b/src/salad_cloud_transcription_sdk/models/transcription_engine.py
@@ -6,9 +6,9 @@ class TranscriptionEngine(Enum):
     Enum representing the different transcription engine options.
 
     Options:
-        - Complete: Complete transcription engine which siupports all features
+        - Full: Full transcription engine which supports all features
         - Lite: Lightweight transcription engine with less features, aimed at being faster
     """
 
-    Complete = "complete"
+    Full = "full"
     Lite = "lite"

--- a/src/salad_cloud_transcription_sdk/models/transcription_job_file_output.py
+++ b/src/salad_cloud_transcription_sdk/models/transcription_job_file_output.py
@@ -60,6 +60,8 @@ class TranscriptionJobFileOutput(BaseModel):
         """
         import json
 
+        print("hello")
+
         if isinstance(json_data, dict):
             data = json_data
         else:

--- a/src/salad_cloud_transcription_sdk/models/transcription_job_file_output.py
+++ b/src/salad_cloud_transcription_sdk/models/transcription_job_file_output.py
@@ -60,8 +60,6 @@ class TranscriptionJobFileOutput(BaseModel):
         """
         import json
 
-        print("hello")
-
         if isinstance(json_data, dict):
             data = json_data
         else:

--- a/src/salad_cloud_transcription_sdk/net/environment/environment.py
+++ b/src/salad_cloud_transcription_sdk/net/environment/environment.py
@@ -5,7 +5,7 @@ An enum class containing all the possible environments for the SDK
 from enum import Enum
 from urllib.parse import urlparse
 
-COMPLETE_TRANSCRIPTION_ENDPOINT_NAME = "transcribe"
+FULL_TRANSCRIPTION_ENDPOINT_NAME = "transcribe"
 LITE_TRANSCRIPTION_ENDPOINT_NAME = "transcription-lite"
 
 

--- a/src/salad_cloud_transcription_sdk/net/environment/environment.py
+++ b/src/salad_cloud_transcription_sdk/net/environment/environment.py
@@ -5,7 +5,8 @@ An enum class containing all the possible environments for the SDK
 from enum import Enum
 from urllib.parse import urlparse
 
-TRANSCRIPTION_ENDPOINT_NAME = "transcribe"
+COMPLETE_TRANSCRIPTION_ENDPOINT_NAME = "transcribe"
+LITE_TRANSCRIPTION_ENDPOINT_NAME = "transcription-lite"
 
 
 class Environment(Enum):

--- a/src/salad_cloud_transcription_sdk/sdk.py
+++ b/src/salad_cloud_transcription_sdk/sdk.py
@@ -1,6 +1,7 @@
 from typing import Union, Optional
 from .services.transcription import TranscriptionService
 from .models.transcription_request import TranscriptionRequest
+from .models.transcription_engine import TranscriptionEngine
 from salad_cloud_sdk.models import InferenceEndpointJob, InferenceEndpointJobCollection
 
 from .net.environment import Environment
@@ -21,9 +22,11 @@ class SaladCloudTranscriptionSdk:
         self._base_url = (
             base_url.value if isinstance(base_url, Environment) else base_url
         )
-        
-        self.transcription = TranscriptionService(base_url=self._base_url, api_key=api_key)
-        
+
+        self.transcription = TranscriptionService(
+            base_url=self._base_url, api_key=api_key
+        )
+
         self.set_api_key(api_key, api_key_header)
         self.set_timeout(timeout)
 
@@ -32,6 +35,7 @@ class SaladCloudTranscriptionSdk:
         source: str,
         organization_name: str,
         request: TranscriptionRequest,
+        engine: TranscriptionEngine = TranscriptionEngine.Complete,
         auto_poll: bool = False,
     ) -> InferenceEndpointJob:
         """Creates a new transcription job
@@ -42,9 +46,11 @@ class SaladCloudTranscriptionSdk:
         :type organization_name: str
         :param request: The transcription request options
         :type request: TranscriptionRequest
+        :param engine: The transcription engine to use, defaults to TranscriptionEngine.Complete
+        :type engine: TranscriptionEngine, optional
         :param auto_poll: Whether to block until the transcription is complete, or return immediately
         :type auto_poll: bool, optional (default=False)
-        
+
         :return: The transcription job details
         :rtype: InferenceEndpointJob
         """
@@ -52,25 +58,27 @@ class SaladCloudTranscriptionSdk:
             source=source,
             organization_name=organization_name,
             request=request,
-            auto_poll=auto_poll
+            engine=engine,
+            auto_poll=auto_poll,
         )
-    
-    def get_transcription_job(self, organization_name: str, job_id: str) -> InferenceEndpointJob:
+
+    def get_transcription_job(
+        self, organization_name: str, job_id: str
+    ) -> InferenceEndpointJob:
         """Get the status of a transcription job
 
         :param organization_name: The organization name
         :type organization_name: str
         :param job_id: The transcription job ID
         :type job_id: str
-        
+
         :return: The transcription job details
         :rtype: InferenceEndpointJob
         """
         return self.transcription.get_transcription_job(
-            organization_name=organization_name,
-            job_id=job_id
+            organization_name=organization_name, job_id=job_id
         )
-    
+
     def delete_transcription_job(self, organization_name: str, job_id: str) -> None:
         """Cancels a transcription job
 
@@ -80,15 +88,14 @@ class SaladCloudTranscriptionSdk:
         :type job_id: str
         """
         return self.transcription.delete_transcription_job(
-            organization_name=organization_name,
-            job_id=job_id
+            organization_name=organization_name, job_id=job_id
         )
-    
+
     def list_transcription_jobs(
-        self, 
-        organization_name: str, 
-        page: Optional[int] = None, 
-        page_size: Optional[int] = None
+        self,
+        organization_name: str,
+        page: Optional[int] = None,
+        page_size: Optional[int] = None,
     ) -> InferenceEndpointJobCollection:
         """Lists all transcription jobs for an organization
 
@@ -98,14 +105,12 @@ class SaladCloudTranscriptionSdk:
         :type page: Optional[int], optional
         :param page_size: The maximum number of items per page, defaults to None
         :type page_size: Optional[int], optional
-        
+
         :return: Collection of transcription jobs
         :rtype: InferenceEndpointJobCollection
         """
         return self.transcription.list_transcription_jobs(
-            organization_name=organization_name,
-            page=page,
-            page_size=page_size
+            organization_name=organization_name, page=page, page_size=page_size
         )
 
     def set_base_url(self, base_url: Union[Environment, str]):

--- a/src/salad_cloud_transcription_sdk/sdk.py
+++ b/src/salad_cloud_transcription_sdk/sdk.py
@@ -35,7 +35,7 @@ class SaladCloudTranscriptionSdk:
         source: str,
         organization_name: str,
         request: TranscriptionRequest,
-        engine: TranscriptionEngine = TranscriptionEngine.Complete,
+        engine: TranscriptionEngine = TranscriptionEngine.Full,
         auto_poll: bool = False,
     ) -> InferenceEndpointJob:
         """Creates a new transcription job
@@ -46,7 +46,7 @@ class SaladCloudTranscriptionSdk:
         :type organization_name: str
         :param request: The transcription request options
         :type request: TranscriptionRequest
-        :param engine: The transcription engine to use, defaults to TranscriptionEngine.Complete
+        :param engine: The transcription engine to use, defaults to TranscriptionEngine.Full
         :type engine: TranscriptionEngine, optional
         :param auto_poll: Whether to block until the transcription is complete, or return immediately
         :type auto_poll: bool, optional (default=False)

--- a/src/salad_cloud_transcription_sdk/services/transcription.py
+++ b/src/salad_cloud_transcription_sdk/services/transcription.py
@@ -24,7 +24,7 @@ from ..models.transcription_job_file_output import TranscriptionJobFileOutput
 from .simple_storage import SimpleStorageService
 from ..net.environment.environment import (
     Environment,
-    COMPLETE_TRANSCRIPTION_ENDPOINT_NAME,
+    FULL_TRANSCRIPTION_ENDPOINT_NAME,
     LITE_TRANSCRIPTION_ENDPOINT_NAME,
 )
 from ..models.transcription_engine import TranscriptionEngine
@@ -68,7 +68,7 @@ class TranscriptionService(BaseService):
         source: str,
         organization_name: str,
         request: TranscriptionRequest,
-        engine: TranscriptionEngine = TranscriptionEngine.Complete,
+        engine: TranscriptionEngine = TranscriptionEngine.Full,
         auto_poll: bool = False,
         max_polling_duration: int = MAX_POLLING_DURATION,
     ) -> InferenceEndpointJob:
@@ -80,8 +80,8 @@ class TranscriptionService(BaseService):
         :type organization_name: str
         :param request: The transcription request options
         :type request: TranscriptionRequest
-        :param engine: The transcription engine to use (Complete or Lite)
-        :type engine: TranscriptionEngine, optional (default=TranscriptionEngine.Complete)
+        :param engine: The transcription engine to use (Full or Lite)
+        :type engine: TranscriptionEngine, optional (default=TranscriptionEngine.Full)
         :param auto_poll: Whether to block until the transcription is complete, or return immediately
         :type auto_poll: bool, optional (default=False)
         :param max_polling_duration: Maximum duration in seconds to poll for job completion
@@ -187,7 +187,7 @@ class TranscriptionService(BaseService):
             return upload_response.url
 
     def _get_endpoint_name(
-        self, engine: TranscriptionEngine = TranscriptionEngine.Complete
+        self, engine: TranscriptionEngine = TranscriptionEngine.Full
     ) -> str:
         """Get the appropriate endpoint name based on the transcription engine
 
@@ -199,14 +199,14 @@ class TranscriptionService(BaseService):
         return (
             LITE_TRANSCRIPTION_ENDPOINT_NAME
             if engine == TranscriptionEngine.Lite
-            else COMPLETE_TRANSCRIPTION_ENDPOINT_NAME
+            else FULL_TRANSCRIPTION_ENDPOINT_NAME
         )
 
     def get_transcription_job(
         self,
         organization_name: str,
         job_id: str,
-        engine: TranscriptionEngine = TranscriptionEngine.Complete,
+        engine: TranscriptionEngine = TranscriptionEngine.Full,
     ) -> InferenceEndpointJob:
         """Get a transcription job by providing the inference job ID
 
@@ -215,7 +215,7 @@ class TranscriptionService(BaseService):
         :param job_id: The transcription job ID
         :type job_id: str
         :param engine: The transcription engine to use
-        :type engine: TranscriptionEngine, optional (default=TranscriptionEngine.Complete)
+        :type engine: TranscriptionEngine, optional (default=TranscriptionEngine.Full)
 
         :return: The transcription job details
         :rtype: InferenceEndpointJob
@@ -226,7 +226,7 @@ class TranscriptionService(BaseService):
         self,
         organization_name: str,
         job_id: str,
-        engine: TranscriptionEngine = TranscriptionEngine.Complete,
+        engine: TranscriptionEngine = TranscriptionEngine.Full,
     ) -> InferenceEndpointJob:
         inference_endpoint_name = self._get_endpoint_name(engine)
         job = self._salad_sdk.inference_endpoints.get_inference_endpoint_job(
@@ -242,7 +242,7 @@ class TranscriptionService(BaseService):
     def list_transcription_jobs(
         self,
         organization_name: str,
-        engine: TranscriptionEngine = TranscriptionEngine.Complete,
+        engine: TranscriptionEngine = TranscriptionEngine.Full,
         page: Optional[int] = None,
         page_size: Optional[int] = None,
     ):
@@ -251,7 +251,7 @@ class TranscriptionService(BaseService):
         :param organization_name: The organization name
         :type organization_name: str
         :param engine: The transcription engine to use
-        :type engine: TranscriptionEngine, optional (default=TranscriptionEngine.Complete)
+        :type engine: TranscriptionEngine, optional (default=TranscriptionEngine.Full)
         :param page: The page number, defaults to None
         :type page: Optional[int], optional
         :param page_size: The maximum number of items per page, defaults to None
@@ -272,7 +272,7 @@ class TranscriptionService(BaseService):
         self,
         organization_name: str,
         job_id: str,
-        engine: TranscriptionEngine = TranscriptionEngine.Complete,
+        engine: TranscriptionEngine = TranscriptionEngine.Full,
     ) -> None:
         """Cancels a transcription job
 
@@ -281,7 +281,7 @@ class TranscriptionService(BaseService):
         :param job_id: The transcription job ID
         :type job_id: str
         :param engine: The transcription engine to use
-        :type engine: TranscriptionEngine, optional (default=TranscriptionEngine.Complete)
+        :type engine: TranscriptionEngine, optional (default=TranscriptionEngine.Full)
 
         :raises RequestError: Raised when a request fails.
         """

--- a/src/salad_cloud_transcription_sdk/services/transcription.py
+++ b/src/salad_cloud_transcription_sdk/services/transcription.py
@@ -63,22 +63,6 @@ class TranscriptionService(BaseService):
         self._storage_service = SimpleStorageService(api_key=api_key)
         self._salad_sdk = SaladCloudSdk(api_key=api_key, base_url=_base_url)
 
-    def _get_endpoint_name(
-        self, engine: TranscriptionEngine = TranscriptionEngine.Complete
-    ) -> str:
-        """Get the appropriate endpoint name based on the transcription engine
-
-        :param engine: The transcription engine to use
-        :type engine: TranscriptionEngine
-        :return: The endpoint name
-        :rtype: str
-        """
-        return (
-            LITE_TRANSCRIPTION_ENDPOINT_NAME
-            if engine == TranscriptionEngine.Lite
-            else COMPLETE_TRANSCRIPTION_ENDPOINT_NAME
-        )
-
     def transcribe(
         self,
         source: str,
@@ -201,6 +185,22 @@ class TranscriptionService(BaseService):
             )
 
             return upload_response.url
+
+    def _get_endpoint_name(
+        self, engine: TranscriptionEngine = TranscriptionEngine.Complete
+    ) -> str:
+        """Get the appropriate endpoint name based on the transcription engine
+
+        :param engine: The transcription engine to use
+        :type engine: TranscriptionEngine
+        :return: The endpoint name
+        :rtype: str
+        """
+        return (
+            LITE_TRANSCRIPTION_ENDPOINT_NAME
+            if engine == TranscriptionEngine.Lite
+            else COMPLETE_TRANSCRIPTION_ENDPOINT_NAME
+        )
 
     def get_transcription_job(
         self,

--- a/src/salad_cloud_transcription_sdk/services/transcription.py
+++ b/src/salad_cloud_transcription_sdk/services/transcription.py
@@ -29,10 +29,6 @@ from ..net.environment.environment import (
 )
 from ..models.transcription_engine import TranscriptionEngine
 
-# Constants for endpoint names
-COMPLETE_TRANSCRIPTION_ENDPOINT_NAME = "whisper"
-LITE_TRANSCRIPTION_ENDPOINT_NAME = "whisper-lite"
-
 
 class TranscriptionService(BaseService):
     """Service for interacting with Salad Cloud Transcription API"""

--- a/tests/test_transcription_service_lite.py
+++ b/tests/test_transcription_service_lite.py
@@ -64,6 +64,9 @@ def test_lite_transcribe_local_file(transcription_service):
     assert job is not None
     assert job.id_ is not None
 
+    print(job.output)
+    print(type(job.output))
+
     assert isinstance(job.output, TranscriptionJobOutput)
     assert isinstance(job.output.text, str)
     assert isinstance(job.output.word_segments, list)
@@ -73,7 +76,9 @@ def test_lite_transcribe_local_file(transcription_service):
 
     # Verify we can retrieve the job
     retrieved_job = transcription_service.get_transcription_job(
-        organization_name=TestConfig.ORGANIZATION_NAME, job_id=job.id_
+        organization_name=TestConfig.ORGANIZATION_NAME,
+        job_id=job.id_,
+        engine=TranscriptionEngine.Lite,
     )
 
     assert retrieved_job.id_ == job.id_
@@ -127,7 +132,9 @@ def test_lite_transcribe_local_file_with_webhook(transcription_service):
 
     # Verify we can retrieve the job
     retrieved_job = transcription_service.get_transcription_job(
-        organization_name=TestConfig.ORGANIZATION_NAME, job_id=job.id_
+        organization_name=TestConfig.ORGANIZATION_NAME,
+        job_id=job.id_,
+        engine=TranscriptionEngine.Lite,
     )
 
     assert retrieved_job.id_ == job.id_
@@ -193,7 +200,9 @@ def test_lite_transcribe_remote_file(transcription_service, simple_storage_servi
 
     # Verify we can retrieve the job
     retrieved_job = transcription_service.get_transcription_job(
-        organization_name=TestConfig.ORGANIZATION_NAME, job_id=job.id_
+        organization_name=TestConfig.ORGANIZATION_NAME,
+        job_id=job.id_,
+        engine=TranscriptionEngine.Lite,
     )
 
     assert retrieved_job.id_ == job.id_
@@ -252,7 +261,9 @@ def test_lite_transcribe_should_return_file(transcription_service):
 
     # Verify we can retrieve the job
     retrieved_job = transcription_service.get_transcription_job(
-        organization_name=TestConfig.ORGANIZATION_NAME, job_id=job.id_
+        organization_name=TestConfig.ORGANIZATION_NAME,
+        job_id=job.id_,
+        engine=TranscriptionEngine.Lite,
     )
 
     assert isinstance(retrieved_job.output, TranscriptionJobFileOutput)

--- a/tests/test_transcription_service_lite.py
+++ b/tests/test_transcription_service_lite.py
@@ -1,0 +1,262 @@
+import os
+import tempfile
+import pytest
+import json
+from salad_cloud_transcription_sdk.models.transcription_job_file_output import (
+    TranscriptionJobFileOutput,
+)
+from salad_cloud_transcription_sdk.models.transcription_job_input import (
+    TranscriptionJobInput,
+)
+from salad_cloud_sdk.net.transport.request_error import RequestError
+from salad_cloud_transcription_sdk.models.transcription_job_output import (
+    TranscriptionJobOutput,
+)
+from salad_cloud_transcription_sdk.services.transcription import TranscriptionService
+from salad_cloud_transcription_sdk.models.transcription_request import (
+    TranscriptionRequest,
+)
+from salad_cloud_transcription_sdk.models.transcription_engine import (
+    TranscriptionEngine,
+)
+from salad_cloud_transcription_sdk.services.simple_storage import SimpleStorageService
+from .config import TestConfig
+
+
+def test_lite_transcribe_local_file(transcription_service):
+    """Test transcribing a local file using the Lite engine"""
+    request = TranscriptionRequest(
+        options=TranscriptionJobInput(
+            language_code="en",
+            return_as_file=False,
+            translate="to_eng",
+            sentence_level_timestamps=True,
+            word_level_timestamps=True,
+            diarization=True,
+            sentence_diarization=True,
+            srt=True,
+            # Adding required parameters with null/empty values
+            summarize=0,
+            custom_vocabulary="",
+            llm_translation=[],
+            srt_translation=[],
+        ),
+        metadata={"test_id": "integration_test", "environment": "testing"},
+    )
+
+    local_file_path = os.path.join("tests", "data", "small_video.mp4")
+
+    try:
+        job = transcription_service.transcribe(
+            source=local_file_path,
+            organization_name=TestConfig.ORGANIZATION_NAME,
+            auto_poll=True,
+            request=request,
+            engine=TranscriptionEngine.Lite,
+        )
+        print(job)
+    except RequestError as e:
+        error_details = {"message": str(e), "response_body": e.response.__str__()}
+        print(f"RequestError: {json.dumps(error_details, indent=4)}")
+        raise
+
+    # Assert that we got a job back with an ID
+    assert job is not None
+    assert job.id_ is not None
+
+    assert isinstance(job.output, TranscriptionJobOutput)
+    assert isinstance(job.output.text, str)
+    assert isinstance(job.output.word_segments, list)
+    assert isinstance(job.output.sentence_level_timestamps, list)
+    assert isinstance(job.output.srt_content, str)
+    assert isinstance(job.output.duration_in_seconds, float)
+
+    # Verify we can retrieve the job
+    retrieved_job = transcription_service.get_transcription_job(
+        organization_name=TestConfig.ORGANIZATION_NAME, job_id=job.id_
+    )
+
+    assert retrieved_job.id_ == job.id_
+
+
+@pytest.mark.skip(
+    reason="Skipping this because it requires a webhook to be configured manually"
+)
+def test_lite_transcribe_local_file_with_webhook(transcription_service):
+    """Test transcribing a local file using the Lite engine with a webhook"""
+    request = TranscriptionRequest(
+        options=TranscriptionJobInput(
+            language_code="en",
+            return_as_file=False,
+            translate="to_eng",
+            sentence_level_timestamps=True,
+            word_level_timestamps=True,
+            diarization=True,
+            sentence_diarization=True,
+            srt=True,
+            # Adding required parameters with null/empty values
+            summarize=0,
+            custom_vocabulary="",
+            llm_translation=[],
+            srt_translation=[],
+        ),
+        metadata={"test_id": "integration_test", "environment": "testing"},
+        webhook="https://webhook.site/a8efbfcb-6b57-49f2-a389-5e58f3a6cb45",
+    )
+
+    local_file_path = os.path.join("tests", "data", "small_video.mp4")
+
+    try:
+        job = transcription_service.transcribe(
+            source=local_file_path,
+            organization_name=TestConfig.ORGANIZATION_NAME,
+            auto_poll=False,
+            request=request,
+            engine=TranscriptionEngine.Lite,
+        )
+
+        print(job)
+    except RequestError as e:
+        error_details = {"message": str(e), "response_body": e.response.__str__()}
+        print(f"RequestError: {json.dumps(error_details, indent=4)}")
+        raise
+
+    # Assert that we got a job back with an ID
+    assert job is not None
+    assert job.id_ is not None
+
+    # Verify we can retrieve the job
+    retrieved_job = transcription_service.get_transcription_job(
+        organization_name=TestConfig.ORGANIZATION_NAME, job_id=job.id_
+    )
+
+    assert retrieved_job.id_ == job.id_
+
+
+def test_lite_transcribe_remote_file(transcription_service, simple_storage_service):
+    """Test transcribing a remote file using the Lite engine"""
+    request = TranscriptionRequest(
+        options=TranscriptionJobInput(
+            language_code="en",
+            return_as_file=False,
+            translate="to_eng",
+            sentence_level_timestamps=True,
+            word_level_timestamps=True,
+            diarization=True,
+            sentence_diarization=True,
+            srt=True,
+            # Adding required parameters with null/empty values
+            summarize=0,
+            custom_vocabulary="",
+            llm_translation=[],
+            srt_translation=[],
+        ),
+        metadata={"test_id": "integration_test", "environment": "testing"},
+    )
+
+    local_file_path = os.path.join("tests", "data", "small_video.mp4")
+
+    try:
+        upload_response = simple_storage_service.upload_file(
+            organization_name=TestConfig.ORGANIZATION_NAME,
+            local_file_path=local_file_path,
+            mime_type="video/mp4",
+            sign=True,
+            signature_exp=3600,  # 1 hour expiration
+        )
+
+        remote_file_url = upload_response.url
+
+        job = transcription_service.transcribe(
+            source=remote_file_url,
+            organization_name=TestConfig.ORGANIZATION_NAME,
+            auto_poll=True,
+            request=request,
+            engine=TranscriptionEngine.Lite,
+        )
+
+        print(job)
+    except RequestError as e:
+        error_details = {"message": str(e), "response_body": e.response.__str__()}
+        print(f"RequestError: {json.dumps(error_details, indent=4)}")
+        raise
+
+    # Assert that we got a job back with an ID
+    assert job is not None
+    assert job.id_ is not None
+    assert isinstance(job.output, TranscriptionJobOutput)
+    assert isinstance(job.output.text, str)
+    assert isinstance(job.output.word_segments, list)
+    assert isinstance(job.output.sentence_level_timestamps, list)
+    assert isinstance(job.output.srt_content, str)
+    assert isinstance(job.output.duration_in_seconds, float)
+
+    # Verify we can retrieve the job
+    retrieved_job = transcription_service.get_transcription_job(
+        organization_name=TestConfig.ORGANIZATION_NAME, job_id=job.id_
+    )
+
+    assert retrieved_job.id_ == job.id_
+    assert isinstance(retrieved_job.output, TranscriptionJobOutput)
+    assert isinstance(retrieved_job.output.text, str)
+    assert isinstance(retrieved_job.output.word_segments, list)
+    assert isinstance(retrieved_job.output.sentence_level_timestamps, list)
+    assert isinstance(retrieved_job.output.srt_content, str)
+    assert isinstance(retrieved_job.output.duration_in_seconds, float)
+
+
+def test_lite_transcribe_should_return_file(transcription_service):
+    """Test transcribing a local file and returning a file using the Lite engine"""
+    request = TranscriptionRequest(
+        options=TranscriptionJobInput(
+            language_code="en",
+            return_as_file=True,
+            translate="to_eng",
+            sentence_level_timestamps=True,
+            word_level_timestamps=True,
+            diarization=True,
+            sentence_diarization=True,
+            srt=True,
+            # Adding required parameters with null/empty values
+            summarize=0,
+            custom_vocabulary="",
+            llm_translation=[],
+            srt_translation=[],
+        ),
+        metadata={"test_id": "integration_test", "environment": "testing"},
+    )
+
+    local_file_path = os.path.join("tests", "data", "small_video.mp4")
+
+    try:
+        job = transcription_service.transcribe(
+            source=local_file_path,
+            organization_name=TestConfig.ORGANIZATION_NAME,
+            auto_poll=True,
+            request=request,
+            engine=TranscriptionEngine.Lite,
+        )
+
+    except RequestError as e:
+        error_details = {"message": str(e), "response_body": e.response.__str__()}
+        print(f"RequestError: {json.dumps(error_details, indent=4)}")
+        raise
+
+    # Assert that we got a job back with an ID
+    assert job is not None
+    assert job.id_ is not None
+
+    assert isinstance(job.output, TranscriptionJobFileOutput)
+    assert isinstance(job.output.url, str)
+    assert isinstance(job.output.duration_in_seconds, float)
+
+    # Verify we can retrieve the job
+    retrieved_job = transcription_service.get_transcription_job(
+        organization_name=TestConfig.ORGANIZATION_NAME, job_id=job.id_
+    )
+
+    assert isinstance(retrieved_job.output, TranscriptionJobFileOutput)
+    assert isinstance(retrieved_job.output.url, str)
+    assert isinstance(retrieved_job.output.duration_in_seconds, float)
+
+    assert retrieved_job.id_ == job.id_


### PR DESCRIPTION
This adds a new enum to the SDK models, called `TranscriptionEngine` and a new parameter of this enum type to the `transcribe` method. 

Now users can select which transcription endpoint to use by setting this new `engine` parameter to either `Complete` or `Lite`. 